### PR TITLE
Fix 404 when clicking on 'All Posts'

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -42,7 +42,7 @@ menu:
       weight: 1
 
     - name: All Posts
-      url: /post
+      url: /posts
       weight: 2
 
     - name: Categories


### PR DESCRIPTION
Noticed a 404 while browsing https://blog.thalheim.io/