### PR TITLE
fix duplicate word

### DIFF
--- a/content/posts/nix-ld.md
+++ b/content/posts/nix-ld.md
@@ -193,7 +193,6 @@ common libraries to be included in the NixOs configuration as follows:
     zlib
     fuse3
     icu
-    zlib
     nss
     openssl
     curl


### PR DESCRIPTION
Thanks for the blog post! I just noticed a duplicate mention of `zlib` in the config example.